### PR TITLE
Making retryer stateless

### DIFF
--- a/http/client/client_test.go
+++ b/http/client/client_test.go
@@ -1,0 +1,21 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/MovieStoreGuy/retry/http/client"
+)
+
+func TestCreatingClient(t *testing.T) {
+	t.Parallel()
+
+	c, err := client.Default(100)
+	assert.NoError(t, err, `Should not error with the default http client`)
+	assert.NotNil(t, c)
+
+	_, err = client.New(nil, 0)
+	assert.Error(t, err, `Should fail to create with no provided http client`)
+
+}

--- a/http/client/doc_test.go
+++ b/http/client/doc_test.go
@@ -3,18 +3,18 @@ package client_test
 import (
 	"crypto/tls"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/MovieStoreGuy/retry"
 	"github.com/MovieStoreGuy/retry/http/client"
+	"github.com/MovieStoreGuy/retry/http/status"
 	"github.com/MovieStoreGuy/retry/http/transport"
 )
 
 func ExampleDefault() {
 	c, err := client.Default(6, // Sets the static limit of allowed attempts
-		transport.WithNoRetryOnResponseCodes(http.StatusBadGateway, http.StatusServiceUnavailable), // Abort if the response matches one of these
-		transport.WithRetryUntilResponseCodes(http.StatusOK, http.StatusAccepted),                  // Keep retry the request until of these response codes has been returned
+		transport.WithRetryOnStatusCode(http.StatusConflict, http.StatusTooManyRequests),
+		transport.WithRetryOnStatusGroup(status.Group5xx),
 		transport.WithRetryOptions(
 			retry.WithExponentialBackoff(200*time.Millisecond, 1.4),
 			retry.WithJitter(80*time.Millisecond),
@@ -35,20 +35,10 @@ func ExampleNew() {
 	t := &http.Transport{
 		TLSNextProto: make(map[string]func(authority string, c *tls.Conn) http.RoundTripper), // Disable HTTP/2 support
 	}
+
 	c, err := client.New(&http.Client{Transport: t}, 8,
-		transport.WithRetryUntilResponseCodes(http.StatusAccepted, http.StatusOK),
-		transport.WithRateLimitCheck(func(h http.Header) (time.Duration, bool) {
-			remaining, err := strconv.Atoi(h.Get(`X-Limit-Remaining`))
-			if err != nil {
-				// No limit was sent with this request, no need to delay
-				return 0, false
-			}
-			until, err := time.Parse(time.RFC1123, h.Get(`X-Limit-Reset`))
-			if err != nil {
-				return 0, false
-			}
-			return time.Until(until), remaining < 0
-		}),
+		transport.WithRetryOnStatusCode(http.StatusTooManyRequests),
+		transport.WithRetryOnStatusGroup(status.Group5xx),
 	)
 
 	if err != nil {

--- a/http/status/group.go
+++ b/http/status/group.go
@@ -1,0 +1,31 @@
+package status
+
+const (
+	_ int = iota
+	Group1xx
+	Group2xx
+	Group3xx
+	Group4xx
+	Group5xx
+)
+
+var (
+	text = map[int]string{
+		Group1xx: "1xx",
+		Group2xx: "2xx",
+		Group3xx: "3xx",
+		Group4xx: "4xx",
+		Group5xx: "5xx",
+	}
+)
+
+func Group(status int) int {
+	return status / 100
+}
+
+func GroupText(group int) string {
+	if s, ok := text[group]; ok {
+		return s
+	}
+	return "?xx"
+}

--- a/http/status/group_test.go
+++ b/http/status/group_test.go
@@ -1,0 +1,1 @@
+package status_test

--- a/http/transport/round_tripper_benchmark_test.go
+++ b/http/transport/round_tripper_benchmark_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/MovieStoreGuy/retry/http/client"
-	"github.com/MovieStoreGuy/retry/http/transport"
 )
 
 type benchTransport struct {
@@ -38,7 +37,6 @@ func BenchmarkFailingTransport(b *testing.B) {
 		Transport: BenchTransport(http.DefaultTransport, func() {
 			b.ReportAllocs()
 		})}, 1,
-		transport.WithRetryUntilResponseCodes(200),
 	)
 	require.NoError(b, err)
 	req, err := http.NewRequest(http.MethodGet, s.URL, nil)

--- a/http/transport/round_tripper_option.go
+++ b/http/transport/round_tripper_option.go
@@ -4,10 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"sync/atomic"
-	"time"
 
 	"github.com/MovieStoreGuy/retry"
+	"github.com/MovieStoreGuy/retry/http/status"
 )
 
 // Option allow for advanced configuration of the transport being created.
@@ -26,124 +25,50 @@ func WithRetryOptions(opts ...retry.Option) Option {
 	}
 }
 
-// WithNoRetryOnResponseCodes will compare the given response code(s) to
-// what has been returned and if it matches, the retry function will stop retrying before
-// max attempts have been reached.
-// To ensure that this check will stop retries, it is prepended to the start of retry checks.
-func WithNoRetryOnResponseCodes(codes ...int) Option {
-	table := make(map[int]struct{}, len(codes))
-	for _, code := range codes {
-		table[code] = struct{}{}
-	}
-	return func(cf *config) error {
+func WithRetryOnStatusCode(codes ...int) Option {
+	return func(c *config) error {
+		table := make(map[int]struct{})
 		for _, code := range codes {
-			if _, exist := cf.table[code]; exist {
-				return fmt.Errorf(`clash on response code [%d:%s]`, code, http.StatusText(code))
+			if _, exist := c.table[code]; exist {
+				return fmt.Errorf("status code %d already exist", code)
 			}
-			cf.table[code] = struct{}{}
+			table[code] = struct{}{}
 		}
-		prepend := []func(*http.Response) error{
-			func(resp *http.Response) error {
-				if resp == nil {
-					return errors.New(`response is nil`)
-				}
-				if _, exist := table[resp.StatusCode]; exist {
-					return retry.AbortedRetries(fmt.Sprintf(`unable to recover response status code: %d`, resp.StatusCode))
-				}
-				return nil
-			},
-		}
-		cf.checks = append(prepend, cf.checks...)
-		return nil
-	}
-}
 
-// WithRetryOnResponseCodes will look at the returned response codes
-// cause the retry function to process the request again
-func WithRetryOnResponseCodes(codes ...int) Option {
-	table := make(map[int]struct{}, len(codes))
-	for _, code := range codes {
-		table[code] = struct{}{}
-	}
-	return func(cf *config) error {
-		for _, code := range codes {
-			if _, exist := cf.table[code]; exist {
-				return fmt.Errorf(`clash on response code [%d:%s]`, code, http.StatusText(code))
+		c.checks = append(c.checks, func(r *http.Response) error {
+			if r == nil {
+				return errors.New("nil response provided")
 			}
-			cf.table[code] = struct{}{}
-		}
-		cf.checks = append(cf.checks, func(resp *http.Response) error {
-			if resp == nil {
-				return errors.New(`response is nil`)
-			}
-			if _, exist := table[resp.StatusCode]; exist {
-				return fmt.Errorf(`returned status code allows retries: %d`, resp.StatusCode)
+			if _, exist := table[r.StatusCode]; exist {
+				return fmt.Errorf("returned status code %d allows retries", r.StatusCode)
 			}
 			return nil
 		})
+
 		return nil
 	}
 }
 
-// WithRetryUntilResponseCodes will force the system to retry until one of the
-// provided codes is meet.
-func WithRetryUntilResponseCodes(codes ...int) Option {
-	table := make(map[int]struct{}, len(codes))
-	for _, code := range codes {
-		table[code] = struct{}{}
-	}
-	return func(cf *config) error {
-		if len(codes) == 0 {
-			return errors.New(`requires at least one response code to compare against`)
-		}
-		for _, code := range codes {
-			if _, exist := cf.table[code]; exist {
-				return fmt.Errorf(`clash on response code [%d:%s]`, code, http.StatusText(code))
+func WithRetryOnStatusGroup(groups ...int) Option {
+	return func(c *config) error {
+		table := make(map[int]struct{})
+		for _, g := range groups {
+			if _, exist := c.table[g]; exist {
+				return fmt.Errorf("status group %dxx already exists", g)
 			}
-			cf.table[code] = struct{}{}
+			table[g] = struct{}{}
 		}
-		cf.checks = append(cf.checks, func(resp *http.Response) error {
-			if _, ok := table[resp.StatusCode]; ok {
-				return nil
+
+		c.checks = append(c.checks, func(r *http.Response) error {
+			if r == nil {
+				return errors.New("nil response provided")
 			}
-			return fmt.Errorf(`unmatched status code %d, continue retrying`, resp.StatusCode)
+			if _, exist := table[status.Group(r.StatusCode)]; exist {
+				return fmt.Errorf("returned status group %dxx allows retries", status.Group(r.StatusCode))
+			}
+			return nil
 		})
-		return nil
-	}
-}
 
-// WithRateLimitCheck allows for dynamic delay based on returned headers from
-// the response. The function must return a positive Duration and true in order to apply
-// the delay once exceeded the allowed rate limit
-func WithRateLimitCheck(limiter func(http.Header) (time.Duration, bool)) Option {
-	delay := int64(0)
-	return func(cf *config) error {
-		if limiter == nil {
-			return errors.New(`limiter function is nil`)
-		}
-		cf.rtOpts = append(cf.rtOpts, retry.WithDynamicDelay(&delay))
-		cf.checks = append(cf.checks, func(resp *http.Response) error {
-			if resp == nil {
-				return errors.New(`response is nil`)
-			}
-
-			// Enforce that dynamic rate limiting must have a status code of 429
-			// to comply with http standards
-			if resp.StatusCode != http.StatusTooManyRequests {
-				return nil
-			}
-
-			t, err := time.Duration(0), error(nil)
-
-			// If we have exceeded the rate limit but the duration to wait has passed
-			// then we have technically not exceeded the current rate limit but a previous one
-
-			if d, exceeded := limiter(resp.Header); exceeded && d > 0 {
-				t, err = d, errors.New(`exceeded rate limit`)
-			}
-			atomic.StoreInt64(&delay, int64(t))
-			return err
-		})
 		return nil
 	}
 }

--- a/http/transport/round_tripper_test.go
+++ b/http/transport/round_tripper_test.go
@@ -71,7 +71,6 @@ func TestRetryClient(t *testing.T) {
 		msg      string
 		opts     []transport.Option
 	}{
-		{status: 400, attempts: 6, expect: 1, endpoint: "/", msg: `Wrapped transport with no retry`, opts: []transport.Option{}},
 		{status: 400, attempts: 6, expect: 6, endpoint: "/", msg: `Wrapped transport with retry on code`, opts: []transport.Option{
 			transport.WithRetryOnStatusCode(400, 500),
 		}},

--- a/http/transport/round_tripper_test.go
+++ b/http/transport/round_tripper_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/MovieStoreGuy/retry"
 	"github.com/MovieStoreGuy/retry/http/client"
+	"github.com/MovieStoreGuy/retry/http/status"
 	"github.com/MovieStoreGuy/retry/http/transport"
 )
 
@@ -25,7 +26,6 @@ func TestCreatingTransport(t *testing.T) {
 	invalid := [][]transport.Option{
 		{transport.WithRetryOptions(retry.WithLogger(nil))},
 		{transport.WithRetryOptions(nil)},
-		{transport.WithRateLimitCheck(nil)},
 	}
 
 	for _, opts := range invalid {
@@ -71,17 +71,15 @@ func TestRetryClient(t *testing.T) {
 		msg      string
 		opts     []transport.Option
 	}{
-		{status: 400, attempts: 6, expect: 1, endpoint: "/", msg: `Wrapped transport with no retry`, opts: []transport.Option{
-			transport.WithNoRetryOnResponseCodes(400, 500),
-		}},
+		{status: 400, attempts: 6, expect: 1, endpoint: "/", msg: `Wrapped transport with no retry`, opts: []transport.Option{}},
 		{status: 400, attempts: 6, expect: 6, endpoint: "/", msg: `Wrapped transport with retry on code`, opts: []transport.Option{
-			transport.WithRetryOnResponseCodes(400, 500),
+			transport.WithRetryOnStatusCode(400, 500),
 		}},
 		{status: 418, attempts: 10, expect: 10, endpoint: "/", msg: `Wrapped transport until status code appears`, opts: []transport.Option{
-			transport.WithRetryUntilResponseCodes(200),
+			transport.WithRetryOnStatusGroup(status.Group4xx),
 		}},
 		{status: 400, attempts: 6, expect: 6, endpoint: "/", msg: `Wrapped transport with retry on code and retry options`, opts: []transport.Option{
-			transport.WithRetryOnResponseCodes(400, 500),
+			transport.WithRetryOnStatusGroup(status.Group4xx, status.Group5xx),
 			transport.WithRetryOptions(
 				retry.WithExponentialBackoff(400*time.Millisecond, 1.2),
 				retry.WithJitter(100*time.Millisecond),


### PR DESCRIPTION
Removing references to atomic and shared memory. This should allow for
removing creating a retryer for each seperate goroutine.

Removes bad patterns of retryingUntil event.