### PR TITLE
Updating error pattern used to allowed for wrapped errors

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -1,6 +1,7 @@
 package retry_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,12 +17,12 @@ func TestWrappedErrors(t *testing.T) {
 		is  func(error) bool
 		msg string
 	}{
-		{err: retry.AbortedRetries(`unable to continue`), is: retry.HasAborted, msg: `Checks to see if an abort error correctly validates`},
-		{err: retry.ExceededRetries(`too many attempts`), is: retry.HasExceeded, msg: `Checks to see if an exceeded error correctly validates`},
-		{err: retry.AbortedRetries(`doom`), is: func(err error) bool {
+		{err: retry.AbortedRetries(errors.New(`unable to continue`)), is: retry.HasAborted, msg: `Checks to see if an abort error correctly validates`},
+		{err: retry.ExceededRetries(errors.New(`too many attempts`)), is: retry.HasExceeded, msg: `Checks to see if an exceeded error correctly validates`},
+		{err: retry.AbortedRetries(errors.New(`doom`)), is: func(err error) bool {
 			return !retry.HasExceeded(err)
 		}, msg: `Ensures an abort error can not validate as exceeded error`},
-		{err: retry.ExceededRetries(`too many attempts`), is: func(err error) bool {
+		{err: retry.ExceededRetries(errors.New(`too many attempts`)), is: func(err error) bool {
 			return !retry.HasAborted(err)
 		}, msg: `Ensures an exceeded error can not validate as an abort error`},
 		{err: nil, is: func(err error) bool { return !retry.HasAborted(err) }, msg: `Ensure that nil does not resolve as an abort`},
@@ -36,6 +37,6 @@ func TestWrappedErrors(t *testing.T) {
 func TestErrorPrinting(t *testing.T) {
 	t.Parallel()
 
-	assert.Contains(t, retry.AbortedRetries("").Error(), `[retry:aborted]`)
-	assert.Contains(t, retry.ExceededRetries("").Error(), `[retry:exceeded]`)
+	assert.Contains(t, retry.AbortedRetries(errors.New("")).Error(), `aborted retries:`)
+	assert.Contains(t, retry.ExceededRetries(errors.New("")).Error(), `exceeded attempts:`)
 }

--- a/http/transport/round_tripper.go
+++ b/http/transport/round_tripper.go
@@ -76,7 +76,7 @@ func (rt *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	err := rt.retryer.DoWithContext(req.Context(), rt.attempts, func() error {
 		r, err := rt.wrapped.RoundTrip(req)
 		if err != nil {
-			return retry.AbortedRetries(err.Error())
+			return retry.AbortedRetries(err)
 		}
 
 		// Checking the response returned and if we fail any of the checks

--- a/retryer.go
+++ b/retryer.go
@@ -80,5 +80,5 @@ func (r *retry) do(ctx context.Context, limit int, f func() error) error {
 		}
 	}
 	// Returns the last error recorded
-	return ExceededRetries(err.Error())
+	return ExceededRetries(err)
 }

--- a/retryer_test.go
+++ b/retryer_test.go
@@ -23,7 +23,7 @@ func TestFailedAttempts(t *testing.T) {
 		msg    string
 	}{
 		{f: func() error { called++; return errors.New(`discard`) }, expect: 4, limit: 4, msg: `testing constant failure`},
-		{f: func() error { called++; return retry.AbortedRetries("doom") }, expect: 1, limit: 2, msg: `testing unrecoverable error`},
+		{f: func() error { called++; return retry.AbortedRetries(errors.New("doom")) }, expect: 1, limit: 2, msg: `testing unrecoverable error`},
 		{f: nil, expect: 0, limit: 1, msg: `testing nil function`},
 		{f: func() error { return nil }, expect: 0, limit: 0, msg: `testing with no attempts`},
 	}


### PR DESCRIPTION
This brings the use of errors inline with go v1.13+